### PR TITLE
Add Single Assignment C (SaC) compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ you want to run is installed and is in PATH.
 - Raku
 - Ruby
 - Rust
+- SaC
 - Scala
 - Swift
 - TypeScript

--- a/src/code_runner/language.rs
+++ b/src/code_runner/language.rs
@@ -39,6 +39,7 @@ pub enum Language {
     Raku,
     Ruby,
     Rust,
+    SaC,
     Scala,
     Swift,
     TypeScript,
@@ -343,6 +344,15 @@ pub fn run_instructions(language: &Language, files: non_empty_vec::NonEmptyVec<p
                     format!("rustc -o a.out {}", main_file_str)
                 ],
                 run_command: "./a.out".to_string()
+            }
+        }
+
+        Language::SaC => {
+            RunInstructions{
+                build_commands: vec![
+                    format!("sac2c -t seq -o a.out {} {}", main_file_str, source_files(other_files, "c")),
+                ],
+                run_command: "./a.out".to_string(),
             }
         }
 


### PR DESCRIPTION
Hi, I'd like to add support for the Single-Assignment C (SaC) compiler (https://sac-home.org/) to glot.io. I've extended `language.rs`, and have tested it locally. I'm currently also adding SaC support to https://github.com/glotcode/glot-images (https://github.com/glotcode/glot-images/pull/3).